### PR TITLE
Error when setting time parameter on track/track once events

### DIFF
--- a/lib/klaviyo/client.rb
+++ b/lib/klaviyo/client.rb
@@ -23,15 +23,17 @@ module Klaviyo
       customer_properties = kwargs[:customer_properties]
       customer_properties[:email] = kwargs[:email] unless kwargs[:email].to_s.empty?
       customer_properties[:id] = kwargs[:id] unless kwargs[:id].to_s.empty?
-      
-      params = build_params({
+
+      params = {
         :token => @api_key,
         :event => event,
         :properties => kwargs[:properties],
         :customer_properties => customer_properties,
         :ip => ''
-      })
+      }
       params[:time] = kwargs[:time].to_time.to_i if kwargs[:time]
+     
+      params = build_params(params)
       request('crm/api/track', params)
     end
     


### PR DESCRIPTION
```
can't convert Symbol into Integer
/Users/mglenn/.rbenv/versions/1.9.3-p327-perf/lib/ruby/gems/1.9.1/gems/klaviyo-0.9.4/lib/klaviyo/client.rb:34:in `[]='
/Users/mglenn/.rbenv/versions/1.9.3-p327-perf/lib/ruby/gems/1.9.1/gems/klaviyo-0.9.4/lib/klaviyo/client.rb:34:in `track'
```

When setting a time for a track event, set the parameter before converting to a base64 encoded string.
