### PR TITLE
Update klaviyo.gemspec

### DIFF
--- a/klaviyo.gemspec
+++ b/klaviyo.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'json'
   s.add_dependency 'rack'
   s.add_dependency 'escape'
-  s.add_dependency 'Faraday'
+  s.add_dependency 'faraday'
 end


### PR DESCRIPTION
Could not find gem 'Faraday', which is required by gem 'klaviyo', in any of the sources

"faraday"