### PR TITLE
Add phone_number as identifying attribute in public API

### DIFF
--- a/lib/klaviyo/apis/public.rb
+++ b/lib/klaviyo/apis/public.rb
@@ -8,16 +8,18 @@ module Klaviyo
     def self.identify(kwargs = {})
       defaults = {:id => nil,
                   :email => nil,
+                  :phone_number => nil,
                   :properties => {}
                  }
       kwargs = defaults.merge(kwargs)
 
-      if !check_email_or_id_exists(kwargs)
+      unless check_required_args(kwargs)
         return
       end
 
       properties = kwargs[:properties]
       properties[:email] = kwargs[:email] unless kwargs[:email].to_s.empty?
+      properties[:phone_number] = kwargs[:phone_number] unless kwargs[:phone_number].to_s.empty?
       properties[:id] = kwargs[:id] unless kwargs[:id].to_s.empty?
 
       params = {
@@ -33,6 +35,7 @@ module Klaviyo
     # @param event [String] the event to track
     # @kwarg :id [String] the customer or profile id
     # @kwarg :email [String] the customer or profile email
+    # @kwarg :phone_number [String] the customer or profile phone number
     # @kwarg :properties [Hash] properties of the event
     # @kwargs :customer_properties [Hash] properties of the customer or profile
     # @kwargs :time [Integer] timestamp of the event
@@ -40,6 +43,7 @@ module Klaviyo
       defaults = {
         :id => nil,
         :email => nil,
+        :phone_number => nil,
         :properties => {},
         :customer_properties => {},
         :time => nil
@@ -47,12 +51,13 @@ module Klaviyo
 
       kwargs = defaults.merge(kwargs)
 
-      if !check_email_or_id_exists(kwargs)
+      unless check_required_args(kwargs)
         return
       end
 
       customer_properties = kwargs[:customer_properties]
       customer_properties[:email] = kwargs[:email] unless kwargs[:email].to_s.empty?
+      customer_properties[:phone_number] = kwargs[:phone_number] unless kwargs[:phone_number].to_s.empty?
       customer_properties[:id] = kwargs[:id] unless kwargs[:id].to_s.empty?
 
       params = {

--- a/lib/klaviyo/client.rb
+++ b/lib/klaviyo/client.rb
@@ -63,9 +63,9 @@ module Klaviyo
       "data=#{Base64.encode64(JSON.generate(params)).gsub(/\n/,'')}"
     end
 
-    def self.check_email_or_id_exists(kwargs)
-      if kwargs[:email].to_s.empty? and kwargs[:id].to_s.empty?
-        raise Klaviyo::KlaviyoError.new(NO_ID_OR_EMAIL_ERROR)
+    def self.check_required_args(kwargs)
+      if kwargs[:email].to_s.empty? and kwargs[:phone_number].to_s.empty? and kwargs[:id].to_s.empty?
+        raise Klaviyo::KlaviyoError.new(REQUIRED_ARG_ERROR)
       else
         return true
       end

--- a/lib/klaviyo/klaviyo_module.rb
+++ b/lib/klaviyo/klaviyo_module.rb
@@ -19,5 +19,5 @@ module Klaviyo
 
   NO_PRIVATE_API_KEY_ERROR = 'Please provide your Private API key for this request'
   NO_PUBLIC_API_KEY_ERROR = 'Please provide your Public API key for this request'
-  NO_ID_OR_EMAIL_ERROR = 'You must identify a user by email or ID'
+  REQUIRED_ARG_ERROR = 'You must identify a user by email, ID or phone_number'
 end


### PR DESCRIPTION
As described in #15, adding support for `phone_number` attribute in public APIs (making email or id optional)