### PR TITLE
add CGI.escape for URL Encoding

### DIFF
--- a/lib/klaviyo/client.rb
+++ b/lib/klaviyo/client.rb
@@ -60,7 +60,7 @@ module Klaviyo
     end
 
     def self.build_params(params)
-      "data=#{Base64.encode64(JSON.generate(params)).gsub(/\n/,'')}"
+      "data=#{CGI.escape(Base64.encode64(JSON.generate(params)).gsub(/\n/, ''))}"
     end
 
     def self.check_required_args(kwargs)


### PR DESCRIPTION
Sometimes data was not sending to Klaviyo. For some objects it returned "0" (failure).
I contacted with Klaviyo support, checked how params are built and found that this library is missing URL Encoding.

Unless this PR is merged you can use this code in your project to avoid issues:
```
# frozen_string_literal: true

module Klaviyo
  module ClientDecorator
    def self.prepended(base)
      class << base
        def build_params(params)
          "data=#{CGI.escape(Base64.encode64(JSON.generate(params)).gsub(/\n/, ''))}"
        end
      end
    end
  end
end

Klaviyo::Client.prepend(Klaviyo::ClientDecorator)
```