### PR TITLE
202104 track request fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## CHANGELOG
 
+### 2.0.6
+
+* Update track request for compatibility w/ Ruby v3.0+
+* Update track request to accept time as integer
+
 ### 2.0.5
 
 * Add basic templates API support

--- a/klaviyo.gemspec
+++ b/klaviyo.gemspec
@@ -2,8 +2,8 @@ files = ['klaviyo.gemspec', '{lib}/**/**/*'].map {|f| Dir[f]}.flatten
 
 Gem::Specification.new do |s|
   s.name        = 'klaviyo'
-  s.version     = '2.0.5'
-  s.date        = '2021-04-05'
+  s.version     = '2.0.6'
+  s.date        = '2021-04-08'
   s.summary     = 'You heard us, a Ruby wrapper for the Klaviyo API'
   s.description = 'Ruby wrapper for the Klaviyo API'
   s.authors     = ['Klaviyo Team']

--- a/lib/klaviyo/apis/public.rb
+++ b/lib/klaviyo/apis/public.rb
@@ -66,9 +66,9 @@ module Klaviyo
         :properties => kwargs[:properties],
         :customer_properties => customer_properties
       }
-      params[:time] = kwargs[:time].to_time.to_i if kwargs[:time]
+      params[:time] = kwargs[:time] if kwargs[:time]
 
-      public_request(HTTP_GET, 'track', params)
+      public_request(HTTP_GET, 'track', **params)
     end
 
     def self.track_once(event, kwargs = {})


### PR DESCRIPTION
This pr updates the track request to send the params as keyword args instead of a hash.  Also fixes how the 'time' param is handled in the track request so that it accepts a timestamp integer instead of a string so that it's consistent with the docs.