### PR TITLE
use ** when passing kwargs as the final parameter for ruby 3

### DIFF
--- a/lib/klaviyo/apis/data_privacy.rb
+++ b/lib/klaviyo/apis/data_privacy.rb
@@ -2,7 +2,7 @@ module Klaviyo
   class DataPrivacy < Client
     DATA_PRIVACY = 'data-privacy'
     DELETION_REQUEST = 'deletion-request'
-    
+
     # Submits a data privacy-related deletion request
     # @param id_type [String] 'email' or 'phone_number' or 'person_id
     # @param identifier [String] value for the identifier specified
@@ -11,9 +11,9 @@ module Klaviyo
       unless ['email', 'phone_number', 'person_id'].include? id_type
         raise Klaviyo::KlaviyoError.new(INVALID_ID_TYPE_ERROR)
       end
-      identifier = { id_type => identifier }      
+      identifier = { id_type => identifier }
       path = "#{DATA_PRIVACY}/#{DELETION_REQUEST}"
-      v2_request(HTTP_POST, path, identifier)
+      v2_request(HTTP_POST, path, **identifier)
     end
   end
 end

--- a/lib/klaviyo/apis/email_templates.rb
+++ b/lib/klaviyo/apis/email_templates.rb
@@ -37,7 +37,7 @@ module Klaviyo
         name: name,
         html: html
       }
-      v1_request(HTTP_PUT, path, params)
+      v1_request(HTTP_PUT, path, **params)
     end
 
     # Deletes a given template.

--- a/lib/klaviyo/apis/lists.rb
+++ b/lib/klaviyo/apis/lists.rb
@@ -14,7 +14,7 @@ module Klaviyo
       body = {
         :list_name => list_name
       }
-      v2_request(HTTP_POST, LISTS, body)
+      v2_request(HTTP_POST, LISTS, **body)
     end
 
     # Retrieves all the lists in the Klaviyo account
@@ -40,7 +40,7 @@ module Klaviyo
       body = {
         :list_name => list_name
       }
-      v2_request(HTTP_PUT, path, body)
+      v2_request(HTTP_PUT, path, **body)
     end
 
     # Deletes a list
@@ -65,7 +65,7 @@ module Klaviyo
         :phone_numbers => phone_numbers,
         :push_tokens => push_tokens
       }
-      v2_request(HTTP_GET, path, params)
+      v2_request(HTTP_GET, path, **params)
     end
 
     # Subscribe profiles to a list.
@@ -80,7 +80,7 @@ module Klaviyo
       params = {
         :profiles => profiles
       }
-      v2_request(HTTP_POST, path, params)
+      v2_request(HTTP_POST, path, **params)
     end
 
     # Unsubscribe and remove profiles from a list
@@ -92,7 +92,7 @@ module Klaviyo
       params = {
         :emails => emails
       }
-      v2_request(HTTP_DELETE, path, params)
+      v2_request(HTTP_DELETE, path, **params)
     end
 
     # Add profiles to a list
@@ -106,7 +106,7 @@ module Klaviyo
       params = {
         :profiles => profiles
       }
-      v2_request(HTTP_POST, path, params)
+      v2_request(HTTP_POST, path, **params)
     end
 
     # Check if profiles are on a list
@@ -123,7 +123,7 @@ module Klaviyo
         :phone_numbers => phone_numbers,
         :push_tokens => push_tokens
       }
-      v2_request(HTTP_GET, path, params)
+      v2_request(HTTP_GET, path, **params)
     end
 
     # Remove profiles from a list
@@ -139,7 +139,7 @@ module Klaviyo
         :phone_numbers => phone_numbers,
         :push_tokens => push_tokens
       }
-      v2_request(HTTP_DELETE, path, params)
+      v2_request(HTTP_DELETE, path, **params)
     end
 
     # Get all emails, phone numbers, along with reasons for list exclusion
@@ -151,7 +151,7 @@ module Klaviyo
       params = {
         :marker => marker
       }
-      v2_request(HTTP_GET, path, params)
+      v2_request(HTTP_GET, path, **params)
     end
 
     # Get all of the emails, phone numbers, and push tokens for profiles in a given list or segment

--- a/lib/klaviyo/apis/metrics.rb
+++ b/lib/klaviyo/apis/metrics.rb
@@ -11,7 +11,7 @@ module Klaviyo
         :page => page,
         :count => count
       }
-      v1_request(HTTP_GET, METRICS, params)
+      v1_request(HTTP_GET, METRICS, **params)
     end
 
     # Returns a batched timeline of all events in your Klaviyo account.
@@ -26,7 +26,7 @@ module Klaviyo
         :count => count,
         :sort => sort
       }
-      v1_request(HTTP_GET, path, params)
+      v1_request(HTTP_GET, path, **params)
     end
 
     # Returns a batched timeline for one specific type of metric.
@@ -42,7 +42,7 @@ module Klaviyo
         :count => count,
         :sort => sort
       }
-      v1_request(HTTP_GET, path, params)
+      v1_request(HTTP_GET, path, **params)
     end
 
     # Export event data, optionally filtering and segmented on available event properties
@@ -74,7 +74,7 @@ module Klaviyo
         :by => by,
         :count => count
       }
-      v1_request(HTTP_GET, path, params)
+      v1_request(HTTP_GET, path, **params)
     end
   end
 end

--- a/lib/klaviyo/apis/profiles.rb
+++ b/lib/klaviyo/apis/profiles.rb
@@ -12,7 +12,7 @@ module Klaviyo
       params = {
         :email => email
       }
-      v2_request(HTTP_GET, path, params)
+      v2_request(HTTP_GET, path, **params)
     end
 
     # Retrieve all the data attributes for a Klaviyo Person ID.
@@ -29,7 +29,7 @@ module Klaviyo
     # @return returns the updated person object
     def self.update_person_attributes(person_id, kwargs = {})
       path = "#{PERSON}/#{person_id}"
-      v1_request(HTTP_PUT, path, kwargs)
+      v1_request(HTTP_PUT, path, **kwargs)
     end
 
     # Listing a person's event timeline
@@ -45,7 +45,7 @@ module Klaviyo
         :count => count,
         :sort => sort
       }
-      v1_request(HTTP_GET, path, params)
+      v1_request(HTTP_GET, path, **params)
     end
 
     # Listing a person's event timeline for a particular metric
@@ -62,7 +62,7 @@ module Klaviyo
         :count => count,
         :sort => sort
       }
-      v1_request(HTTP_GET, path, params)
+      v1_request(HTTP_GET, path, **params)
     end
   end
 end

--- a/lib/klaviyo/apis/public.rb
+++ b/lib/klaviyo/apis/public.rb
@@ -27,7 +27,7 @@ module Klaviyo
         :properties => properties
       }
 
-      public_request(HTTP_GET, 'identify', params)
+      public_request(HTTP_GET, 'identify', **params)
     end
 
     # Used for tracking events and customer behaviors

--- a/lib/klaviyo/client.rb
+++ b/lib/klaviyo/client.rb
@@ -55,7 +55,7 @@ module Klaviyo
         }
         data[:body] = data[:body].merge(kwargs[:params])
         full_url = "#{V1_API}/#{path}"
-        request(method, full_url, content_type, data)
+        request(method, full_url, content_type, **data)
       else
         defaults = {:page => nil,
                     :count => nil,
@@ -75,7 +75,7 @@ module Klaviyo
       }
       data = {}
       data[:body] = key.merge(kwargs)
-      request(method, path, CONTENT_JSON, data)
+      request(method, path, CONTENT_JSON, **data)
     end
 
     def self.build_params(params)


### PR DESCRIPTION
In ruby 3 when you declare a function to accept variable keyword arguments like this:

```
def self.v1_request(method, path, content_type: CONTENT_JSON, **kwargs)
```

you can't pass those arguments like this:

```
      params = {
        :since => since,
        :count => count,
        :sort => sort
      }
      v1_request(HTTP_GET, path, params)
```

Instead, you have to use the double splat before that final kwargs argument like this:

```
v1_request(HTTP_GET, path, **params)
```

That type of call works in ruby 2 and 3, and in fact this library is already using it in one case [here](https://github.com/klaviyo/ruby-klaviyo/blob/master/lib/klaviyo/apis/public.rb#L71). This changes the remainder of the calls to the various `request` methods to also use it. My text editor seems to have also made 2 other small changes that remove trailing whitespace.