### PR TITLE
202109 thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### 2.1.0
+* Update for thread-safety
+
 ### 2.0.9
 
 * Added ability to make POST requests to public api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## CHANGELOG
 
 ### 2.1.0
-* Update for thread-safety
+* Update structure to create instances of API classes
 
 ### 2.0.9
 

--- a/README.md
+++ b/README.md
@@ -22,24 +22,21 @@ gem install klaviyo
 API Examples
 ------------
 
-Require the Klaviyo module in the file, and then set your Public and Private API keys:
+Require the Klaviyo module in the file:
 
 ```ruby
 # require the klaviyo module
 require 'klaviyo'
-
-# set your 6 digit Public API key
-Klaviyo.public_api_key = 'YOUR_PUBLIC_API_KEY'
-
-# set your Private API key
-Klaviyo.private_api_key = 'YOUR_PRIVATE_API_KEY'
 ```
 
 Public:
 
 ```ruby
+# set your public API key
+@public = Klaviyo::Public.new('PUBLIC_API_KEY')
+
 # used to track events
-Klaviyo::Public.track(
+@public.track(
   'Filled out profile',
   email: 'someone@mailinator.com',
   properties: {
@@ -48,7 +45,7 @@ Klaviyo::Public.track(
 )
 
 # using a phone number to track events
-Klaviyo::Public.track(
+@public.track(
   'TestedSMSContact',
   phone_number: '+15555555555',
   properties: {
@@ -57,7 +54,7 @@ Klaviyo::Public.track(
 )
 
 # used for identifying customers and managing profile properties
-Klaviyo::Public.identify(
+@public.identify(
   email: 'thomas.jefferson@mailinator.com',
   properties: {
     '$first_name': 'Thomas',
@@ -67,7 +64,7 @@ Klaviyo::Public.identify(
 )
 
 # using a POST request to track events
-Klaviyo::Public.track(
+@public.track(
   'Filled out profile',
   method: 'post',
   email: 'someone@mailinator.com',
@@ -80,23 +77,26 @@ Klaviyo::Public.track(
 Lists:
 
 ```ruby
+# create a new Lists instance and set the private API key
+@lists = Klaviyo::Lists.new('PRIVATE_API_KEY')
+
 # to add a new list
-Klaviyo::Lists.create_list('NEW_LIST_NAME')
+@lists.create_list('NEW_LIST_NAME')
 
 # to get all lists
-Klaviyo::Lists.get_lists()
+@lists.get_lists()
 
 # to get list details
-Klaviyo::Lists.get_list_details('LIST_ID')
+@lists.get_list_details('LIST_ID')
 
 # to update a list name
-Klaviyo::Lists.update_list_details('LIST_ID', 'LIST_NAME_UPDATED')
+@lists.update_list_details('LIST_ID', 'LIST_NAME_UPDATED')
 
 # to delete a list
-Klaviyo::Lists.delete_list('LIST_ID')
+@lists.delete_list('LIST_ID')
 
 # to check email address subscription status to a list
-Klaviyo::Lists.check_list_subscriptions(
+@lists.check_list_subscriptions(
   'LIST_ID',
   emails: ['test1@example.com'],
   phone_numbers: ['5555555555'],
@@ -104,7 +104,7 @@ Klaviyo::Lists.check_list_subscriptions(
 )
 
 # to add subscribers to a list, this will follow the lists double opt in settings
-Klaviyo::Lists.add_subscribers_to_list(
+@lists.add_subscribers_to_list(
   'LIST_ID',
   profiles: [
     {
@@ -117,13 +117,13 @@ Klaviyo::Lists.add_subscribers_to_list(
 )
 
 # to unsubscribe and remove profile from a list and suppress a profile
-Klaviyo::Lists.unsubscribe_from_list(
+@lists.unsubscribe_from_list(
   'LIST_ID',
   emails: ['test1@example.com']
 )
 
 # to add members to a list, this doesn't care about the list double opt in setting
-Klaviyo::Lists.add_to_list(
+@lists.add_to_list(
   'LIST_ID',
   profiles: [
     {
@@ -136,7 +136,7 @@ Klaviyo::Lists.add_to_list(
 )
 
 # to check email profiles if they're in a list
-Klaviyo::Lists.check_list_memberships(
+@lists.check_list_memberships(
   'LIST_ID',
   emails: ['test1@example.com'],
   phone_numbers: ['5555555555'],
@@ -144,7 +144,7 @@ Klaviyo::Lists.check_list_memberships(
 )
 
 # to remove profiles from a list
-Klaviyo::Lists.remove_from_list(
+@lists.remove_from_list(
   'LIST_ID',
   emails: ['test1@example.com'],
   phone_numbers: ['5555555555'],
@@ -152,30 +152,33 @@ Klaviyo::Lists.remove_from_list(
 )
 
 # to get exclusion emails from a list - marker is used for paginating
-Klaviyo::Lists.get_list_exclusions('LIST_ID', marker: 'EXAMPLE_MARKER')
+@lists.get_list_exclusions('LIST_ID', marker: 'EXAMPLE_MARKER')
 
 # to get all members in a group or list
-Klaviyo::Lists.get_group_members('LIST_ID')
+@lists.get_group_members('LIST_ID')
 ```
 
 Profiles:
 
 ```ruby
+# create a new Profiles instance and set the private API key
+@profiles = Klaviyo::Profiles.new('PRIVATE_API_KEY')
+
 # get profile id by email
-Klaviyo::Profiles.get_profile_id_by_email('EMAIL')
+@profiles.get_profile_id_by_email('EMAIL')
 
 # get profile by profile_id
-Klaviyo::Profiles.get_person_attributes('PROFILE_ID')
+@profiles.get_person_attributes('PROFILE_ID')
 
 # update a profile
-Klaviyo::Profiles.update_person_attributes(
+@profiles.update_person_attributes(
   'PROFILE_ID',
   PropertyName1: 'value',
   PropertyName2: 'value'
 )
 
 # get all metrics for a profile with the default kwargs
-Klaviyo::Profiles.get_person_metrics_timeline(
+@profiles.get_person_metrics_timeline(
   'PROFILE_ID',
   since: nil,
   count: 100,
@@ -183,7 +186,7 @@ Klaviyo::Profiles.get_person_metrics_timeline(
 )
 
 # get all events of a metric for a profile with the default kwargs
-Klaviyo::Profiles.get_person_metric_timeline(
+@profiles.get_person_metric_timeline(
   'PROFILE_ID',
   'METRIC_ID',
   since: nil,
@@ -195,18 +198,21 @@ Klaviyo::Profiles.get_person_metric_timeline(
 Metrics:
 
 ```ruby
+# create a new Metrics instance and set the private API key
+@metrics = Klaviyo::Metrics.new('PRIVATE_API_KEY')
+
 # get all metrics with the default kwargs
-Klaviyo::Metrics.get_metrics(page: 0, count: 100)
+@metrics.get_metrics(page: 0, count: 100)
 
 # get a batched timeline of all metrics with the default kwargs
-Klaviyo::Metrics.get_metrics_timeline(
+@metrics.get_metrics_timeline(
   since: nil,
   count: 100,
   sort: 'desc'
 )
 
 # get a batched timeline of a single metric with the default kwargs
-Klaviyo::Metrics.get_metric_timeline(
+@metrics.get_metric_timeline(
   'METRIC_ID',
   since: nil,
   count: 100,
@@ -214,7 +220,7 @@ Klaviyo::Metrics.get_metric_timeline(
 )
 
 # export data for a single metric
-Klaviyo::Metrics.get_metric_export(
+@metrics.get_metric_export(
   'METRIC_ID',
   start_date: nil,
   end_date: nil,
@@ -229,44 +235,50 @@ Klaviyo::Metrics.get_metric_export(
 Campaigns:
 
 ```ruby
+# create a new Campaigns instance and set the private API key
+@campaigns = Klaviyo::Campaigns.new('PRIVATE_API_KEY')
+
 # get Campaigns
-Klaviyo::Campaigns.get_campaigns()
+@campaigns.get_campaigns()
 
 # get specific Campaign details
-Klaviyo::Campaigns.get_campaign_details('CAMPAIGN_ID')
+@campaigns.get_campaign_details('CAMPAIGN_ID')
 
 # send Campaign
-Klaviyo::Campaigns.send_campaign('CAMPAIGN_ID')
+@campaigns.send_campaign('CAMPAIGN_ID')
 
 # cancel Campaign
-Klaviyo::Campaigns.cancel_campaign('CAMPAIGN_ID')
+@campaigns.cancel_campaign('CAMPAIGN_ID')
 ```
 
 Email Templates:
 
 ```ruby
+# create a new EmailTemplates instance and set the private API key
+@emailTemplates = Klaviyo::EmailTemplates.new('PRIVATE_API_KEY')
+
 # get templates
-Klaviyo::EmailTemplates.get_templates()
+@emailTemplates.get_templates()
 
 # create a new template
-Klaviyo::EmailTemplates.create_template(name: 'TEMPLATE_NAME', html: 'TEMPLATE_HTML')
+@emailTemplates.create_template(name: 'TEMPLATE_NAME', html: 'TEMPLATE_HTML')
 
 # update template
 # does not update drag & drop templates at this time
-Klaviyo::EmailTemplates.update_template(
+@emailTemplates.update_template(
   'TEMPLATE_ID',
   name: 'UPDATED_TEMPLATE_NAME',
   html: 'UPDATED_TEMPLATE_HTML'
 )
 
 # delete template
-Klaviyo::EmailTemplates.delete_template('TEMPLATE_ID')
+@emailTemplates.delete_template('TEMPLATE_ID')
 
 # clone a template with a new name
-Klaviyo::EmailTemplates.clone_template('TEMPLATE_ID', 'NEW_TEMPLATE_NAME')
+@emailTemplates.clone_template('TEMPLATE_ID', 'NEW_TEMPLATE_NAME')
 
 # render template - returns html and text versions of template
-Klaviyo::EmailTemplates.render_template(
+@emailTemplates.render_template(
   'TEMPLATE_ID',
   context: {
     name: 'RECIPIENT_NAME',
@@ -275,7 +287,7 @@ Klaviyo::EmailTemplates.render_template(
 )
 
 # send template
-Klaviyo::EmailTemplates.send_template(
+@emailTemplates.send_template(
   'TEMPLATE_ID',
   from_email: 'FROM_EMAIL_ADDRESS',
   from_name: 'FROM_EMAIL_NAME',
@@ -291,14 +303,17 @@ Klaviyo::EmailTemplates.send_template(
 Data Privacy:
 
 ```ruby
+# create a new DataPrivacy instance and set the private API key
+@dataPrivacy = Klaviyo::DataPrivacy.new('PRIVATE_API_KEY')
+
 # delete profile by email
-Klaviyo::DataPrivacy.request_profile_deletion('email','EMAIL')
+@dataPrivacy.request_profile_deletion('email','EMAIL')
 
 # delete profile by phone number
-Klaviyo::DataPrivacy.request_profile_deletion('phone_number','PHONE_NUMBER')
+@dataPrivacy.request_profile_deletion('phone_number','PHONE_NUMBER')
 
 # delete profile by person id
-Klaviyo::DataPrivacy.request_profile_deletion('person_id','PERSON_ID')
+@dataPrivacy.request_profile_deletion('person_id','PERSON_ID')
 ```
 
 How to use it with a Rails application?
@@ -313,21 +328,20 @@ config.middleware.use "Klaviyo::Client::Middleware", "YOUR_PUBLIC_KLAVIYO_API_TO
 
 This will automatically insert the Klaviyo script at the bottom on your HTML page, right before the closing `body` tag.
 
-To record customer actions directly from your backend, in your `application_controller` class add a method to initialize set your public and private API tokens.
+To record customer actions directly from your backend, in your `application_controller` class add a method to initialize and set your public API token.
 
 ```ruby
 require 'klaviyo'
 
 class ApplicationController < ActionController::Base
-  Klaviyo.public_api_key = 'YOUR_PUBLIC_API_KEY'
-  Klaviyo.private_api_key = 'YOUR_PRIVATE_API_KEY'
+  @public = Klaviyo::Public.new('PUBLIC_API_KEY')
 end
 ```
 
 Then in your controllers where you'd like to record an event:
 
 ```ruby
-Klaviyo::Public.track('Did something important',
+@public.track('Did something important',
   email: 'john.smith@example.com',
   properties:
   {

--- a/klaviyo.gemspec
+++ b/klaviyo.gemspec
@@ -2,8 +2,8 @@ files = ['klaviyo.gemspec', '{lib}/**/**/*'].map {|f| Dir[f]}.flatten
 
 Gem::Specification.new do |s|
   s.name        = 'klaviyo'
-  s.version     = '2.0.9'
-  s.date        = '2021-07-30'
+  s.version     = '2.1.0'
+  s.date        = '2021-09-28'
   s.summary     = 'You heard us, a Ruby wrapper for the Klaviyo API'
   s.description = 'Ruby wrapper for the Klaviyo API'
   s.authors     = ['Klaviyo Team']

--- a/lib/klaviyo/apis/campaigns.rb
+++ b/lib/klaviyo/apis/campaigns.rb
@@ -7,14 +7,14 @@ module Klaviyo
 
      # Retrieves all the campaigns from Klaviyo account
      # @return [List] of JSON formatted campaing objects
-    def self.get_campaigns()
+    def get_campaigns()
       v1_request(HTTP_GET, CAMPAIGNS)
     end
 
     # Retrieves the details of the list
     # @param campaign_id the if of campaign
     # @return [JSON] a JSON object containing information about the campaign
-    def self.get_campaign_details(campaign_id)
+    def get_campaign_details(campaign_id)
       path = "#{CAMPAIGN}/#{campaign_id}"
 
       v1_request(HTTP_GET, path)
@@ -23,7 +23,7 @@ module Klaviyo
     # Sends the campaign immediately
     # @param campaign_id [String] the id of campaign
     # @return will return with HTTP ok in case of success
-    def self.send_campaign(campaign_id)
+    def send_campaign(campaign_id)
       path = "#{CAMPAIGN}/#{campaign_id}/#{SEND}"
 
       v1_request(HTTP_POST, path)
@@ -32,7 +32,7 @@ module Klaviyo
     # Cancels the campaign with specified campaign_id
     # @param campaign_id [String] the id of campaign
     # @return [JSON] a JSON object containing the campaign details
-    def self.cancel_campaign(campaign_id)
+    def cancel_campaign(campaign_id)
       path = "#{CAMPAIGN}/#{campaign_id}/#{CANCEL}"
 
       v1_request(HTTP_POST, path)

--- a/lib/klaviyo/apis/campaigns.rb
+++ b/lib/klaviyo/apis/campaigns.rb
@@ -1,5 +1,9 @@
 module Klaviyo
   class Campaigns < Client
+    def initialize(private_api_key)
+      @private_api_key = private_api_key
+    end
+
     CANCEL = 'cancel'
     CAMPAIGN = 'campaign'
     CAMPAIGNS = 'campaigns'

--- a/lib/klaviyo/apis/data_privacy.rb
+++ b/lib/klaviyo/apis/data_privacy.rb
@@ -1,5 +1,9 @@
 module Klaviyo
   class DataPrivacy < Client
+    def initialize(private_api_key)
+      @private_api_key = private_api_key
+    end
+
     DATA_PRIVACY = 'data-privacy'
     DELETION_REQUEST = 'deletion-request'
 

--- a/lib/klaviyo/apis/data_privacy.rb
+++ b/lib/klaviyo/apis/data_privacy.rb
@@ -7,7 +7,7 @@ module Klaviyo
     # @param id_type [String] 'email' or 'phone_number' or 'person_id
     # @param identifier [String] value for the identifier specified
     # @return a dictionary with a confirmation that deletion task submitted for the customer
-    def self.request_profile_deletion(id_type, identifier)
+    def request_profile_deletion(id_type, identifier)
       unless ['email', 'phone_number', 'person_id'].include? id_type
         raise Klaviyo::KlaviyoError.new(INVALID_ID_TYPE_ERROR)
       end

--- a/lib/klaviyo/apis/email_templates.rb
+++ b/lib/klaviyo/apis/email_templates.rb
@@ -9,7 +9,7 @@ module Klaviyo
     # Returns a list of all the email templates you've created.
     # The templates are returned in sorted order by name.
     # @return [List] of JSON formatted email template objects
-    def self.get_templates()
+    def get_templates()
       v1_request(HTTP_GET, EMAIL_TEMPLATES)
     end
 
@@ -17,7 +17,7 @@ module Klaviyo
     # @param :name [String] The name of the email template
     # @param :html [String] The HTML content for this template
     # @return [JSON] a JSON object containing information about the email template
-    def self.create_template(name: nil, html: nil)
+    def create_template(name: nil, html: nil)
       params = {
         name: name,
         html: html
@@ -31,7 +31,7 @@ module Klaviyo
     # @param :name [String] The name of the email template
     # @param :html [String] The HTML content for this template
     # @return [JSON] a JSON object containing information about the email template
-    def self.update_template(template_id, name:, html:)
+    def update_template(template_id, name:, html:)
       path = "#{EMAIL_TEMPLATE}/#{template_id}"
       params = {
         name: name,
@@ -43,7 +43,7 @@ module Klaviyo
     # Deletes a given template.
     # @param template_id [String] The id of the email template
     # @return [JSON] a JSON object containing information about the email template
-    def self.delete_template(template_id)
+    def delete_template(template_id)
       path = "#{EMAIL_TEMPLATE}/#{template_id}"
       v1_request(HTTP_DELETE, path)
     end
@@ -52,7 +52,7 @@ module Klaviyo
     # @param template_id [String] The id of the email template to copy
     # @param :name [String] The name of the newly cloned email template
     # @return [JSON] a JSON object containing information about the email template
-    def self.clone_template(template_id, name:)
+    def clone_template(template_id, name:)
       path = "#{EMAIL_TEMPLATE}/#{template_id}/#{CLONE}"
       params = {
         name: name
@@ -65,7 +65,7 @@ module Klaviyo
     # @param template_id [String] The id of the email template to copy
     # @param :context [Hash] The context the email template will be rendered with
     # @return [JSON] a JSON object containing information about the email template
-    def self.render_template(template_id, context: {})
+    def render_template(template_id, context: {})
       path = "#{EMAIL_TEMPLATE}/#{template_id}/#{RENDER}"
       params = {
         context: context
@@ -82,7 +82,7 @@ module Klaviyo
     # @param :to [Mixed] The email this template is being sent to
     # @param :context [Hash] The context the email template will be rendered with
     # @return [JSON] a JSON object containing information about the email template
-    def self.send_template(template_id, from_email:, from_name:, subject:, to:, context: {})
+    def send_template(template_id, from_email:, from_name:, subject:, to:, context: {})
       path = "#{EMAIL_TEMPLATE}/#{template_id}/#{SEND}"
       params = {
         from_email: from_email,

--- a/lib/klaviyo/apis/email_templates.rb
+++ b/lib/klaviyo/apis/email_templates.rb
@@ -1,5 +1,9 @@
 module Klaviyo
   class EmailTemplates < Client
+    def initialize(private_api_key)
+      @private_api_key = private_api_key
+    end
+
     EMAIL_TEMPLATES = 'email-templates'
     EMAIL_TEMPLATE = 'email-template'
     CLONE = 'clone'

--- a/lib/klaviyo/apis/lists.rb
+++ b/lib/klaviyo/apis/lists.rb
@@ -10,7 +10,7 @@ module Klaviyo
     # Creates a new list
     # @param list_name [String] the list name
     # @return will return with HTTP OK on success
-    def self.create_list(list_name)
+    def create_list(list_name)
       body = {
         :list_name => list_name
       }
@@ -19,14 +19,14 @@ module Klaviyo
 
     # Retrieves all the lists in the Klaviyo account
     # @return [List] a list of JSON objects of the name and id for each list
-    def self.get_lists()
+    def get_lists()
       v2_request(HTTP_GET, LISTS)
     end
 
     # Retrieves the details of the list
     # @param list_id [String] the id of the list
     # @return [JSON] a JSON object containing information about the list
-    def self.get_list_details(list_id)
+    def get_list_details(list_id)
       path = "#{LIST}/#{list_id}"
       v2_request(HTTP_GET, path)
     end
@@ -35,7 +35,7 @@ module Klaviyo
     # @param list_id [String] the id of the list
     # @param list_name [String] the new name of the list
     # @return will return with HTTP OK on success
-    def self.update_list_details(list_id, list_name)
+    def update_list_details(list_id, list_name)
       path = "#{LIST}/#{list_id}"
       body = {
         :list_name => list_name
@@ -46,7 +46,7 @@ module Klaviyo
     # Deletes a list
     # @param list_id [String] the id of the list
     # @return will return with HTTP OK on success
-    def self.delete_list(list_id)
+    def delete_list(list_id)
       path = "#{LIST}/#{list_id}"
       v2_request(HTTP_DELETE, path)
     end
@@ -58,7 +58,7 @@ module Klaviyo
     # @param :push_tokens [List] push tokens of the profiles to check
     # @return A list of JSON objects of the profiles. Profiles that are
     #   supressed or not found are not included.
-    def self.check_list_subscriptions(list_id, emails: [], phone_numbers: [], push_tokens: [])
+    def check_list_subscriptions(list_id, emails: [], phone_numbers: [], push_tokens: [])
       path = "#{LIST}/#{list_id}/#{SUBSCRIBE}"
       params = {
         :emails => emails,
@@ -75,7 +75,7 @@ module Klaviyo
     # @return will retun HTTP OK on success. If the list is single opt-in then a
     #   list of records containing the email address, phone number, push token,
     #   and the corresponding profile ID will also be included.
-    def self.add_subscribers_to_list(list_id, profiles: [])
+    def add_subscribers_to_list(list_id, profiles: [])
       path = "#{LIST}/#{list_id}/#{SUBSCRIBE}"
       params = {
         :profiles => profiles
@@ -87,7 +87,7 @@ module Klaviyo
     # @param list_id [String] the id of the list
     # @param :emails [List] the emails of the profiles to check
     # @return will return with HTTP OK on success
-    def self.unsubscribe_from_list(list_id, emails: [])
+    def unsubscribe_from_list(list_id, emails: [])
       path = "#{LIST}/#{list_id}/#{SUBSCRIBE}"
       params = {
         :emails => emails
@@ -101,7 +101,7 @@ module Klaviyo
     #   that will be added to the list
     # @return will return with HTTP OK on success and a list of records of the
     #   corresponding profile id
-    def self.add_to_list(list_id, profiles: [])
+    def add_to_list(list_id, profiles: [])
       path = "#{LIST}/#{list_id}/#{MEMBERS}"
       params = {
         :profiles => profiles
@@ -116,7 +116,7 @@ module Klaviyo
     # @param :push_tokens [List] push tokens of the profiles to check
     # @return A list of JSON objects of the profiles. Profiles that are
     #   supressed or not found are not included.
-    def self.check_list_memberships(list_id, emails: [], phone_numbers: [], push_tokens: [])
+    def check_list_memberships(list_id, emails: [], phone_numbers: [], push_tokens: [])
       path = "#{LIST}/#{list_id}/#{MEMBERS}"
       params = {
         :emails => emails,
@@ -132,7 +132,7 @@ module Klaviyo
     # @param :phone_numbers [List] the phone numbers of the profiles to check
     # @param :push_tokens [List] push tokens of the profiles to check
     # @return will return with HTTP OK on success
-    def self.remove_from_list(list_id, emails: [], phone_numbers: [], push_tokens: [])
+    def remove_from_list(list_id, emails: [], phone_numbers: [], push_tokens: [])
       path = "#{LIST}/#{list_id}/#{MEMBERS}"
       params = {
         :emails => emails,
@@ -146,7 +146,7 @@ module Klaviyo
     # @param list_id [String] the id of the list
     # @param marker [Integer] a marker from a previous call to get the next batch
     # @return [List] A list of JSON object for each profile with the reason for exclusion
-    def self.get_list_exclusions(list_id, marker: nil)
+    def get_list_exclusions(list_id, marker: nil)
       path = "#{LIST}/#{list_id}/#{EXCLUSIONS}/#{ALL}"
       params = {
         :marker => marker
@@ -158,7 +158,7 @@ module Klaviyo
     # @param list_id [String] the id of the list
     # @param marker [Integer] a marker from a previous call to get the next batch
     # @return [List] A list of JSON objects for each profile with the id, email, phone number, and push token
-    def self.get_group_members(list_id)
+    def get_group_members(list_id)
       path = "#{GROUP}/#{list_id}/#{MEMBERS}/#{ALL}"
       v2_request(HTTP_GET, path)
     end

--- a/lib/klaviyo/apis/lists.rb
+++ b/lib/klaviyo/apis/lists.rb
@@ -1,5 +1,9 @@
 module Klaviyo
   class Lists < Client
+    def initialize(private_api_key)
+      @private_api_key = private_api_key
+    end
+
     EXCLUSIONS = 'exclusions'
     GROUP = 'group'
     LIST = 'list'

--- a/lib/klaviyo/apis/metrics.rb
+++ b/lib/klaviyo/apis/metrics.rb
@@ -6,7 +6,7 @@ module Klaviyo
     # @param page [Integer] which page to return, default 0
     # @param count [Integer] number of results to return, default 100
     # @return a dictionary with a data property that contains an array of all the metrics
-    def self.get_metrics(page: DEFAULT_PAGE, count: DEFAULT_COUNT)
+    def get_metrics(page: DEFAULT_PAGE, count: DEFAULT_COUNT)
       params = {
         :page => page,
         :count => count
@@ -19,7 +19,7 @@ module Klaviyo
     # @param count [Integer] number of results to return, default 100
     # @param sort [String] 'asc' or 'desc', sort order to apply to the timeline.  Default is 'desc'.
     # @return a dictionary with a data property that contains an array of the metrics
-    def self.get_metrics_timeline(since: nil, count: DEFAULT_COUNT, sort: DEFAULT_SORT_DESC)
+    def get_metrics_timeline(since: nil, count: DEFAULT_COUNT, sort: DEFAULT_SORT_DESC)
       path = "#{METRICS}/#{TIMELINE}"
       params = {
         :since => since,
@@ -35,7 +35,7 @@ module Klaviyo
     # @param count [Integer] number of results to return, default 100
     # @param sort [String] 'asc' or 'desc', sort order to apply to the timeline.  Default is 'desc'.
     # @return a dictionary with a data property that contains information about what metric the event tracks
-    def self.get_metric_timeline(metric_id, since: nil, count: DEFAULT_COUNT, sort: DEFAULT_SORT_DESC)
+    def get_metric_timeline(metric_id, since: nil, count: DEFAULT_COUNT, sort: DEFAULT_SORT_DESC)
       path = "#{METRIC}/#{metric_id}/#{TIMELINE}"
       params = {
         :since => since,
@@ -55,7 +55,7 @@ module Klaviyo
     # @param by [String] The name of a property to segment the event data on. Where and by parameters cannot be specified at the same time.
     # @param count [Integer] Maximum number of segments to return. The default value is 25.
     # @return A dictionary relecting the input request parameters as well as a results property
-    def self.get_metric_export(metric_id,
+    def get_metric_export(metric_id,
                                start_date: nil,
                                end_date: nil,
                                unit: nil,

--- a/lib/klaviyo/apis/metrics.rb
+++ b/lib/klaviyo/apis/metrics.rb
@@ -1,5 +1,9 @@
 module Klaviyo
   class Metrics < Client
+    def initialize(private_api_key)
+      @private_api_key = private_api_key
+    end
+
     EXPORT = 'export'
 
     # Returns a list of all metrics in Klaviyo

--- a/lib/klaviyo/apis/profiles.rb
+++ b/lib/klaviyo/apis/profiles.rb
@@ -1,5 +1,9 @@
 module Klaviyo
   class Profiles < Client
+    def initialize(private_api_key)
+      @private_api_key = private_api_key
+    end
+
     PERSON = 'person'
     PEOPLE = 'people'
     SEARCH = 'search'

--- a/lib/klaviyo/apis/profiles.rb
+++ b/lib/klaviyo/apis/profiles.rb
@@ -7,7 +7,7 @@ module Klaviyo
     # Retrieves the id of the profile given email
     # @param email [String] the email of the profile
     # @return [JSON] a JSON object containing id of the profile
-    def self.get_profile_id_by_email(email)
+    def get_profile_id_by_email(email)
       path = "#{PEOPLE}/#{SEARCH}"
       params = {
         :email => email
@@ -18,7 +18,7 @@ module Klaviyo
     # Retrieve all the data attributes for a Klaviyo Person ID.
     # @param person_id [String] the id of the profile
     # @return returns a person object
-    def self.get_person_attributes(person_id)
+    def get_person_attributes(person_id)
       path = "#{PERSON}/#{person_id}"
       v1_request(HTTP_GET, path)
     end
@@ -27,7 +27,7 @@ module Klaviyo
     # @param person_id [String] the id of the profile
     # @param kwargs [Key/value pairs] attributes to add/update in the profile
     # @return returns the updated person object
-    def self.update_person_attributes(person_id, kwargs = {})
+    def update_person_attributes(person_id, kwargs = {})
       path = "#{PERSON}/#{person_id}"
       v1_request(HTTP_PUT, path, **kwargs)
     end
@@ -38,7 +38,7 @@ module Klaviyo
     # @param count [Integer] number of results to return, default 100
     # @param sort [String] 'asc' or 'desc', sort order to apply to the timeline.  Default is 'desc'.
     # @return returns a dictionary containing a list of metric event objects
-    def self.get_person_metrics_timeline(person_id, since: nil, count: DEFAULT_COUNT, sort: DEFAULT_SORT_DESC)
+    def get_person_metrics_timeline(person_id, since: nil, count: DEFAULT_COUNT, sort: DEFAULT_SORT_DESC)
       path = "#{PERSON}/#{person_id}/#{METRICS}/#{TIMELINE}"
       params = {
         :since => since,
@@ -55,7 +55,7 @@ module Klaviyo
     # @param count [Integer] number of results to return, default 100
     # @param sort [String] 'asc' or 'desc', sort order to apply to the timeline.  Default is 'desc'.
     # @return returns a dictionary containing a list of metric event objects
-    def self.get_person_metric_timeline(person_id, metric_id, since: nil, count: DEFAULT_COUNT, sort: DEFAULT_SORT_DESC)
+    def get_person_metric_timeline(person_id, metric_id, since: nil, count: DEFAULT_COUNT, sort: DEFAULT_SORT_DESC)
       path = "#{PERSON}/#{person_id}/#{METRIC}/#{metric_id}/#{TIMELINE}"
       params = {
         :since => since,

--- a/lib/klaviyo/apis/public.rb
+++ b/lib/klaviyo/apis/public.rb
@@ -7,7 +7,7 @@ module Klaviyo
     # @kwarg :phone_number [String] the customer or profile phone number
     # @kwarg :properties [Hash] properties of the profile to add or update
     # @kwargs :method [String] the HTTP method to use for the request. Accepts 'get' or 'post'.  Defaults to 'get'.
-    def self.identify(kwargs = {})
+    def identify(kwargs = {})
       defaults = {:id => nil,
                   :email => nil,
                   :phone_number => nil,
@@ -26,7 +26,7 @@ module Klaviyo
       properties[:id] = kwargs[:id] unless kwargs[:id].to_s.empty?
 
       params = {
-        :token => Klaviyo.public_api_key,
+        :token => @public_api_key,
         :properties => properties
       }
 
@@ -43,7 +43,7 @@ module Klaviyo
     # @kwargs :customer_properties [Hash] properties of the customer or profile
     # @kwargs :time [Integer] timestamp of the event
     # @kwargs :method [String] the HTTP method to use for the request. Accepts 'get' or 'post'.  Defaults to 'get'.
-    def self.track(event, kwargs = {})
+    def track(event, kwargs = {})
       defaults = {
         :id => nil,
         :email => nil,
@@ -66,7 +66,7 @@ module Klaviyo
       customer_properties[:id] = kwargs[:id] unless kwargs[:id].to_s.empty?
 
       params = {
-        :token => Klaviyo.public_api_key,
+        :token => @public_api_key,
         :event => event,
         :properties => kwargs[:properties],
         :customer_properties => customer_properties
@@ -76,7 +76,7 @@ module Klaviyo
       public_request(kwargs[:method], 'track', **params)
     end
 
-    def self.track_once(event, kwargs = {})
+    def track_once(event, kwargs = {})
       kwargs.update('__track_once__' => true)
       track(event, kwargs)
     end

--- a/lib/klaviyo/apis/public.rb
+++ b/lib/klaviyo/apis/public.rb
@@ -1,5 +1,9 @@
 module Klaviyo
   class Public < Client
+    def initialize(public_api_key)
+      @public_api_key = public_api_key
+    end
+
     # Used for identifying customers and managing profile properties
     #
     # @kwarg :id [String] the customer or profile id

--- a/lib/klaviyo/client.rb
+++ b/lib/klaviyo/client.rb
@@ -1,9 +1,5 @@
 module Klaviyo
   class Client
-    def initialize(public_api_key, private_api_key)
-      @public_api_key = public_api_key
-      @private_api_key = private_api_key
-    end
 
     BASE_API_URL = 'https://a.klaviyo.com/api'
     V1_API = 'v1'

--- a/lib/klaviyo/client.rb
+++ b/lib/klaviyo/client.rb
@@ -1,5 +1,10 @@
 module Klaviyo
   class Client
+    def initialize(public_api_key, private_api_key)
+      @public_api_key = public_api_key
+      @private_api_key = private_api_key
+    end
+
     BASE_API_URL = 'https://a.klaviyo.com/api'
     V1_API = 'v1'
     V2_API = 'v2'
@@ -23,7 +28,7 @@ module Klaviyo
 
     private
 
-    def self.request(method, path, content_type, **kwargs)
+    def request(method, path, content_type, **kwargs)
       check_private_api_key_exists()
       url = "#{BASE_API_URL}/#{path}"
       connection = Faraday.new(
@@ -39,7 +44,7 @@ module Klaviyo
       end
     end
 
-    def self.public_request(method, path, **kwargs)
+    def public_request(method, path, **kwargs)
       check_public_api_key_is_valid()
       if method == HTTP_GET
         params = build_params(kwargs)
@@ -57,11 +62,11 @@ module Klaviyo
       end
     end
 
-    def self.v1_request(method, path, content_type: CONTENT_JSON, **kwargs)
+    def v1_request(method, path, content_type: CONTENT_JSON, **kwargs)
       if content_type == CONTENT_URL_FORM
         data = {
           :body => {
-            :api_key => Klaviyo.private_api_key
+            :api_key => @private_api_key
           }
         }
         data[:body] = data[:body].merge(kwargs[:params])
@@ -74,26 +79,26 @@ module Klaviyo
                     :sort => nil}
         params = defaults.merge(kwargs)
         query_params = encode_params(params)
-        full_url = "#{V1_API}/#{path}?api_key=#{Klaviyo.private_api_key}#{query_params}"
+        full_url = "#{V1_API}/#{path}?api_key=#{@private_api_key}#{query_params}"
         request(method, full_url, content_type)
       end
     end
 
-    def self.v2_request(method, path, **kwargs)
+    def v2_request(method, path, **kwargs)
       path = "#{V2_API}/#{path}"
       key = {
-        "api_key": "#{Klaviyo.private_api_key}"
+        "api_key": "#{@private_api_key}"
       }
       data = {}
       data[:body] = key.merge(kwargs)
       request(method, path, CONTENT_JSON, **data)
     end
 
-    def self.build_params(params)
+    def build_params(params)
       "data=#{CGI.escape(Base64.encode64(JSON.generate(params)).gsub(/\n/, ''))}"
     end
 
-    def self.check_required_args(kwargs)
+    def check_required_args(kwargs)
       if kwargs[:email].to_s.empty? and kwargs[:phone_number].to_s.empty? and kwargs[:id].to_s.empty?
         raise Klaviyo::KlaviyoError.new(REQUIRED_ARG_ERROR)
       else
@@ -101,25 +106,25 @@ module Klaviyo
       end
     end
 
-    def self.check_private_api_key_exists()
-      if !Klaviyo.private_api_key
+    def check_private_api_key_exists()
+      if !@private_api_key
         raise KlaviyoError.new(NO_PRIVATE_API_KEY_ERROR)
       end
     end
 
-    def self.check_public_api_key_is_valid()
-      if !Klaviyo.public_api_key
+    def check_public_api_key_is_valid()
+      if !@public_api_key
         raise KlaviyoError.new(NO_PUBLIC_API_KEY_ERROR)
       end
-      if ( Klaviyo.public_api_key =~ /pk_\w{34}$/ ) == 0
+      if ( @public_api_key =~ /pk_\w{34}$/ ) == 0
         raise KlaviyoError.new(PRIVATE_KEY_AS_PUBLIC)
       end
-      if ( Klaviyo.public_api_key =~ /\w{6}$/ ) != 0
+      if ( @public_api_key =~ /\w{6}$/ ) != 0
         raise KlaviyoError.new(INCORRECT_PUBLIC_API_KEY_LENGTH)
       end
     end
 
-    def self.encode_params(kwargs)
+    def encode_params(kwargs)
       kwargs.select!{|k, v| v}
       params = URI.encode_www_form(kwargs)
 

--- a/lib/klaviyo/klaviyo_module.rb
+++ b/lib/klaviyo/klaviyo_module.rb
@@ -13,10 +13,6 @@ require_relative 'apis/email_templates'
 require_relative 'apis/data_privacy'
 
 module Klaviyo
-  class << self
-    attr_accessor :public_api_key
-    attr_accessor :private_api_key
-  end
 
   class KlaviyoError < StandardError; end
 


### PR DESCRIPTION
This update changes the behavior of the module so that users will create and instance of the API that they wish to use while passing in the public or private API key as necessary.  Creating instances of the API classes resolves the [thread-safety issue raised here ](https://github.com/klaviyo/ruby-klaviyo/issues/32).
